### PR TITLE
Fix an URL in documentation : use HTTPS

### DIFF
--- a/source/integration.rst
+++ b/source/integration.rst
@@ -52,7 +52,7 @@ Some easy examples
 ******************
 
 * Transport mode available in the service
-	* http://api.sncf.com/v1/coverage/sncf/commercial_modes
+	* https://api.sncf.com/v1/coverage/sncf/commercial_modes
 * Which services are available on this coverage? take a look at the links under this URL
 	* https://api.sncf.com/v1/coverage/sncf
 * Networks available?


### PR DESCRIPTION
http://api.sncf.com/v1/coverage/sncf/commercial_modes (don't works) -> https://api.sncf.com/v1/coverage/sncf/commercial_modes (works)
